### PR TITLE
Added --root(-r) option

### DIFF
--- a/gltfjsx.js
+++ b/gltfjsx.js
@@ -6,6 +6,7 @@ const DracoLoader = require('./bin/dracoloader')
 THREE.DRACOLoader.getDecoderModule = () => {}
 const prettier = require('prettier')
 const isVarName = require('is-var-name')
+const path = require('path')
 
 const options = {}
 
@@ -171,7 +172,19 @@ function parseExtras(extras) {
   } else return ''
 }
 
-module.exports = function (file, nameExt, output, exportOptions) {
+function getRelativeFilePath(file, exportOptions) {
+  const filePath = path.resolve(file)
+  const rootPath = exportOptions.root ? path.resolve(exportOptions.root) : path.dirname(file)
+
+  const relativePath = path.relative(rootPath, filePath) || ''
+  if (process.platform === 'win32') {
+    return relativePath.replace(/\\/g, '/')
+  }
+
+  return relativePath
+}
+
+module.exports = function (file, output, exportOptions) {
   return new Promise((resolve, reject) => {
     Object.keys(exportOptions).forEach((key) => (options[key] = exportOptions[key]))
     const stream = fs.createWriteStream(output)
@@ -179,6 +192,7 @@ module.exports = function (file, nameExt, output, exportOptions) {
       if (!fs.existsSync(file)) {
         console.error(`\nERROR: The input file: "${file}" does not exist at this path.\n`)
       } else {
+        const filePath = getRelativeFilePath(file, exportOptions)
         const data = fs.readFileSync(file)
         const arrayBuffer = toArrayBuffer(data)
         gltfLoader.parse(
@@ -205,7 +219,7 @@ export default function Model(props${options.types ? ": JSX.IntrinsicElements['g
   const group = ${options.types ? 'useRef<THREE.Group>()' : 'useRef()'}
   const { nodes, materials${options.animation ? ', animations' : ''} } = useLoader${
               options.types ? '<GLTFResult>' : ''
-            }(GLTFLoader, '/${nameExt}'${options.draco ? `, draco(${JSON.stringify(options.binary)})` : ``})${
+            }(GLTFLoader, '/${filePath}'${options.draco ? `, draco(${JSON.stringify(options.binary)})` : ``})${
               options.animation ? printAnimations(gltf, options) : ``
             }
   return (

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const argv = require('yargs')
   .option('compress', { alias: 'c', default: true, describe: 'Removes names and empty groups', type: 'boolean' })
   .option('precision', { alias: 'p', default: 2, describe: 'Number of fractional digits', type: 'number' })
   .option('binary', { alias: 'b', describe: 'Draco path', default: '/draco-gltf/', type: 'string' })
+  .option('root', { alias: 'r', describe: 'Sets directory from which .gltf file is served', type: 'string' })
   .usage('npx gltfjsx model.gltf [Model.js] [options]')
   .help().argv
 
@@ -22,7 +23,7 @@ if (argv._[0]) {
 
   console.log(`gltfjsx ${version}, converting ${file} to ${output}`)
   console.log('')
-  gltfjsx(file, nameExt, output, argv)
+  gltfjsx(file, output, argv)
     .then(() => console.log('\ndone.'))
     .catch((err) => console.log('\nfailed.\n\n', err))
 } else {

--- a/readme.md
+++ b/readme.md
@@ -14,14 +14,15 @@ $ npx gltfjsx model.gltf [Model.js] [options]
 
 ### Options
 ```bash
-  --draco, -d         Adds draco-Loader                   [boolean]
-  --animation, -a     Extracts animation clips            [boolean]
-  --types, -t         Adds Typescript definitions         [boolean]
-  --compress, -c      Removes names and empty groups      [boolean] [default: true]
-  --precision, -p     Number of fractional digits         [number ] [default: 2]
-  --binary, -b        Draco binaries                      [string ] [default: '/draco-gltf/']
-  --help              Show help                           [boolean]
-  --version           Show version number                 [boolean]
+  --draco, -d         Adds draco-Loader                         [boolean]
+  --animation, -a     Extracts animation clips                  [boolean]
+  --types, -t         Adds Typescript definitions               [boolean]
+  --compress, -c      Removes names and empty groups            [boolean] [default: true]
+  --precision, -p     Number of fractional digits               [number ] [default: 2]
+  --binary, -b        Draco binaries                            [string ] [default: '/draco-gltf/']
+  --root, -r          Sets directory from which .gltf is served [string ]
+  --help              Show help                                 [boolean]
+  --version           Show version number                       [boolean]
 ```
 
 You need to be set up for asset loading and the GLTF has to be present in your /public folder. This tools loads it, creates look-up tables of all the objects and materials inside, and writes out a JSX graph, which you can now alter comfortably. It will not change or alter your files in any way otherwise.


### PR DESCRIPTION
This PR adds `--root`/`-r` option to specify content root from which the `gltf` is served.

Current generated JSX loads the file by its name from root (e.g.: `'/file.gltf'`). 

With the option, JSX will load by relative path from the specified directory.

e.g.:
`$ gltfjsx public/assets/foo.gltf` results in `'/foo.gltf'`

`$ gltfjsx public/assets/foo.gltf --root public` results in `'/assets/foo.gltf'`

