### PR TITLE
Fixed typescript output for models with animations

### DIFF
--- a/src/gltfjsx.js
+++ b/src/gltfjsx.js
@@ -167,7 +167,13 @@ function print(objects, gltf, obj, parent) {
 }
 
 function printAnimations(gltf, animations, options) {
-  return animations.length ? `\nconst { actions } = useAnimations(animations, group)` : ''
+  if (animations.length) {
+    return options.types
+      ? `\nconst { actions } = useAnimations(animations, group as React.MutableRefObject<THREE.Object3D>)`
+      : `\nconst { actions } = useAnimations(animations, group)`
+  }
+
+  return ''
 }
 
 function parseExtras(extras) {


### PR DESCRIPTION
I wanted to throw up a PR for the issue expressed in #60. It's a fairly small change, just typecasting the `Group` ref as `Object3D` for `useAnimations` when the types flag is present.

From my understanding Group and Object3D are essentially the same thing, and they seem to typecast back and forth without issue.

~~Just a note - I wasn't quite sure how to execute the code after making the change in this pr to test it, so it would probably be worth doing a quick test run before if you decide to merge it. I've been manually doing the typecast in own projects and haven't had any issues.~~

Ran as expected.