### PR TITLE
useAnimations typing updated, remove typecast.

### DIFF
--- a/src/gltfjsx.js
+++ b/src/gltfjsx.js
@@ -167,13 +167,7 @@ function print(objects, gltf, obj, parent) {
 }
 
 function printAnimations(gltf, animations, options) {
-  if (animations.length) {
-    return options.types
-      ? `\nconst { actions } = useAnimations(animations, group as React.MutableRefObject<THREE.Object3D>)`
-      : `\nconst { actions } = useAnimations(animations, group)`
-  }
-
-  return ''
+  return animations.length ? `\nconst { actions } = useAnimations(animations, group)` : ''
 }
 
 function parseExtras(extras) {


### PR DESCRIPTION
Drei's `useAnimations` argument types were updated to include `undefined` in the latest version. This typecast will still prevent a ts error in older versions of drei if that's something you want to consider, otherwise it's no longer necessary.