### PR TITLE
Fix parse of animations

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -68,7 +68,10 @@ function parse(fileName, gltf, options = {}) {
       obj.name.length &&
       (options.verbose ||
         obj.morphTargetDictionary ||
-        (hasAnimations && gltf.animations.find((clip) => clip.targetNames.includes(obj.name))))
+        (hasAnimations &&
+          gltf.animations.find(
+            (clip) => clip.name.includes(obj.name) || (clip.targetNames && clip.targetNames.includes(obj.name))
+          )))
     )
       result += `name="${obj.name}" `
 


### PR DESCRIPTION
Related: https://github.com/pmndrs/gltf-react-three/issues/10


Animations are broken if in some versions of GLB if `targetNames` does not exist, this fixes that by checking aswell for `clip.name.includes(obj.name) `