### PR TITLE
Api extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/pmndrs/gltfjsx#readme",
   "bin": "cli.js",
-  "main": "src/utils/parser.js",
+  "main": "src/utils/main.js",
   "engines": {
     "node": ">=10"
   },

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ export default function Model(props: JSX.IntrinsicElements['group']) {
 ## Using the parser stand-alone
 
 ```jsx
-import parse from '@react-three/gltfjsx'
+import { parse } from '@react-three/gltfjsx'
 import { GLTFLoader, DRACOLoader } from 'three-stdlib'
 
 const gltfLoader = new GLTFLoader()

--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,30 @@ gltfLoader.load(url, (gltf) => {
 })
 ```
 
+## Using GLTFStructureLoader stand-alone
+
+The GLTFStructureLoader can come in handy while testing gltf components.
+It allows you to extract the gltf file structure without the actual binaries and textures making it possible to run under a testing environment.
+Avoid using it inside the actual components because it can cause conflicts with the original THREE library methods.
+
+```jsx
+import { GLTFStructureLoader } from '@react-three/gltfjsx'
+import fs from 'fs'
+
+const loadGltf = (gltfFilePath) => {
+	const loader = new GLTFStructureLoader()
+
+	return new Promise((resolve, reject) => {
+		fs.readFile(gltfFilePath, (err, data) => {
+			if (err) reject(err)
+			loader.parse(data, '', res => resolve(res))
+		})
+	})
+}
+...
+
+```
+
 ## Requirements
 
 - Nodejs must be installed

--- a/src/utils/glftLoader.js
+++ b/src/utils/glftLoader.js
@@ -1,0 +1,4 @@
+const THREE = (global.THREE = require('three'))
+require('../bin/GLTFLoader')
+
+module.exports = THREE.GLTFLoader

--- a/src/utils/main.js
+++ b/src/utils/main.js
@@ -1,5 +1,7 @@
 const parse = require('./parser')
+const GLTFLoader = require('./glftLoader')
 
 module.exports = {
-  parse: parse
+  parse,
+  GLTFStructureLoader: GLTFLoader
 }

--- a/src/utils/main.js
+++ b/src/utils/main.js
@@ -1,0 +1,5 @@
+const parse = require('./parser')
+
+module.exports = {
+  parse: parse
+}


### PR DESCRIPTION
It extends an API by GLTFLoader. 
It's a breaking change because the parse function is no longer exported as default.