### PR TITLE
Fix error in parsing typescript file

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -288,10 +288,10 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/
 
         ${
           hasInstances
-            ? `        
+            ? `
         export default function InstancedModel(props) {
           const { nodes } = useGLTF('${url}'${options.draco ? `, ${JSON.stringify(options.draco)}` : ''})${
-                options.types ? ' as GLTFResult' : ''
+                options.types ? ' as unknown as GLTFResult' : ''
               }
           const instances = useMemo(() => ({
             ${Object.values(duplicates.geometries)
@@ -314,13 +314,13 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/
           const group = ${options.types ? 'useRef<THREE.Group>()' : 'useRef()'}
           const { nodes, materials${hasAnimations ? ', animations' : ''} } = useGLTF('${url}'${
     options.draco ? `, ${JSON.stringify(options.draco)}` : ''
-  })${options.types ? ' as GLTFResult' : ''}${printAnimations(animations)}
+  })${options.types ? ' as unknown as GLTFResult' : ''}${printAnimations(animations)}
           return (
             <group ref={group} {...props} dispose={null}>
         ${scene}
             </group>
           )
-        }      
+        }
 
 useGLTF.preload('${url}')`
 }


### PR DESCRIPTION
Fix error in parsing typescript file where GLTF conversion to type 'GLTFResult' may be a mistake because neither type sufficiently overlaps with the other.

Error that occurs: Conversion of type 'GLTF' to type 'GLTFResult' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.