### PR TITLE
Fix TypeScript GLTF type import

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -283,7 +283,7 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/
   }
         ${scene.includes('OrthographicCamera') ? 'OrthographicCamera,' : ''}
         ${hasAnimations ? 'useAnimations' : ''} } from '@react-three/drei'
-        ${options.types ? 'import { GLTF } from "three/examples/jsm/loaders/GLTFLoader"' : ''}
+        ${options.types ? 'import { GLTF } from "three-stdlib"' : ''}
         ${options.types ? printTypes(objects, animations) : ''}
 
         ${
@@ -291,7 +291,7 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/
             ? `
         export default function InstancedModel(props) {
           const { nodes } = useGLTF('${url}'${options.draco ? `, ${JSON.stringify(options.draco)}` : ''})${
-                options.types ? ' as unknown as GLTFResult' : ''
+                options.types ? ' as GLTFResult' : ''
               }
           const instances = useMemo(() => ({
             ${Object.values(duplicates.geometries)
@@ -314,7 +314,7 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/
           const group = ${options.types ? 'useRef<THREE.Group>()' : 'useRef()'}
           const { nodes, materials${hasAnimations ? ', animations' : ''} } = useGLTF('${url}'${
     options.draco ? `, ${JSON.stringify(options.draco)}` : ''
-  })${options.types ? ' as unknown as GLTFResult' : ''}${printAnimations(animations)}
+  })${options.types ? ' as GLTFResult' : ''}${printAnimations(animations)}
           return (
             <group ref={group} {...props} dispose={null}>
         ${scene}


### PR DESCRIPTION
Fixes https://github.com/pmndrs/gltfjsx/issues/113

https://github.com/pmndrs/gltfjsx/commit/57c805d16e4946ed4e1c97d2f1ba4487e101c717 _sort of_ fixes this, but the `GLTF` type should be coming from `three-stdlib`

Type comes from here:
https://github.com/pmndrs/drei/blob/76164ba343aa5c64708a5cfe16b071a7c1d61781/src/core/useGLTF.tsx#L2-L3