### PR TITLE
Add option for output file path/name

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,9 +10,10 @@ const App = importJsx('./src/components/App')
 const cli = meow(
   `
 	Usage
-	  $ npx gltfjsx [Model.js] [options]
+	  $ npx gltfjsx [Model.glb] [options]
 
 	Options
+    --output, -o        Output file name/path
     --types, -t         Add Typescript definitions
     --keepnames, -k     Keep original names
     --keepgroups, -K    Keep (empty) groups
@@ -30,6 +31,7 @@ const cli = meow(
 `,
   {
     flags: {
+      output: { type: 'string', alias: 'o' },
       types: { type: 'boolean', alias: 't' },
       keepnames: { type: 'boolean', alias: 'k' },
       keepgroups: { type: 'boolean', alias: 'K' },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,7 +8,7 @@ const ErrorBoundary = importJsx('./ErrorBoundary')
 function Conversion({ file, ...config }) {
   let nameExt = file.match(/[-_\w]+[.][\w]+$/i)[0]
   let name = nameExt.split('.').slice(0, -1).join('.')
-  let output = name.charAt(0).toUpperCase() + name.slice(1) + (config.types ? '.tsx' : '.js')
+  let output = config.output ?? name.charAt(0).toUpperCase() + name.slice(1) + (config.types ? '.tsx' : '.js')
 
   const [done, setDone] = React.useState(false)
   const [log, setLog] = React.useState([])


### PR DESCRIPTION
Currently the output file name is generated from the model name and the output path is always the working directory. 

This adds an option `--output`, `-o` to override the output file name/path.