### PR TITLE
fix(parser.js): adds `as unknown` when casting `useGLTF` return type

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -395,7 +395,7 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/
         const context = createContext()
         export function Instances({ children, ...props }) {
           const { nodes } = useGLTF('${url}'${options.draco ? `, ${JSON.stringify(options.draco)}` : ''})${
-                options.types ? ' as GLTFResult' : ''
+                options.types ? ' as unkown as GLTFResult' : ''
               }
           const instances = useMemo(() => ({
             ${Object.values(duplicates.geometries)


### PR DESCRIPTION
Adds a patch for https://github.com/pmndrs/gltfjsx/issues/167

More information into why this change: https://github.com/pmndrs/gltfjsx/issues/167#issuecomment-1364471944