### PR TITLE
Update for changes in glTF Transform v3 prerelease.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@gltf-transform/core": "^3.0.0-alpha.3",
-    "@gltf-transform/extensions": "^3.0.0-alpha.3",
-    "@gltf-transform/functions": "^3.0.0-alpha.3",
+    "@gltf-transform/core": "^3.0.0-alpha.4",
+    "@gltf-transform/extensions": "^3.0.0-alpha.4",
+    "@gltf-transform/functions": "^3.0.0-alpha.4",
     "@node-loader/babel": "^2.0.1",
     "draco3dgltf": "^1.5.5",
     "is-var-name": "^2.0.0",

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,6 +1,6 @@
 import { NodeIO } from '@gltf-transform/core'
-import { simplify, weld, dedup, resample, prune, textureCompress } from '@gltf-transform/functions'
-import { DracoMeshCompression, ALL_EXTENSIONS } from '@gltf-transform/extensions'
+import { simplify, weld, dedup, resample, prune, textureCompress, draco } from '@gltf-transform/functions'
+import { ALL_EXTENSIONS } from '@gltf-transform/extensions'
 import { MeshoptDecoder, MeshoptEncoder, MeshoptSimplifier } from 'meshoptimizer'
 import draco3d from 'draco3dgltf'
 import sharp from 'sharp'
@@ -27,6 +27,8 @@ async function transform(file, output, config = {}) {
     prune(),
     // Resize and convert textures (using webp and sharp)
     textureCompress({ targetFormat: 'webp', encoder: sharp, resize: [resolution, resolution] }),
+    // Add Draco compression.
+    draco(),
   ]
 
   if (config.simplify) {
@@ -39,11 +41,6 @@ async function transform(file, output, config = {}) {
   }
 
   await document.transform(...functions)
-
-  // Add Draco compression.
-  document.createExtension(DracoMeshCompression).setRequired(true).setEncoderOptions({
-    method: DracoMeshCompression.EncoderMethod.EDGEBREAKER,
-  })
 
   await io.write(output, document)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,29 +23,29 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gltf-transform/core@^3.0.0-alpha.3":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@gltf-transform/core/-/core-3.0.0-alpha.3.tgz#a0c1831b3a21d79a1d8a5e4e2672f29dd0838c31"
-  integrity sha512-dPpMAd7+nzb9+xzRVgnFkGlmQrpkA0YZLdYztlRMZORuD1uSOpkKkABWNEVFd04hUy7NjyRbgFvdprcM8Sk2fg==
+"@gltf-transform/core@^3.0.0-alpha.4":
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@gltf-transform/core/-/core-3.0.0-alpha.4.tgz#a4d67a1c9a0d18c4215dc361180155b5e41d754c"
+  integrity sha512-fvZFPeq+etlY0TEm3/JBEwvrRY6XI2U2PeqUz/p/5srtRWP5UoWj/v6wX4/GIk1lbNPjHGH8KjVA55b2Ihq6vg==
   dependencies:
     gl-matrix "~3.4.3"
     property-graph "^0.2.6"
 
-"@gltf-transform/extensions@^3.0.0-alpha.3":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@gltf-transform/extensions/-/extensions-3.0.0-alpha.3.tgz#072ccf554e14f6aa5444fc25a26924ac80768013"
-  integrity sha512-XiRvRJvu/lny3uSZw1Qb07vSuWM3IYq0Ebxib340n737YrDZJeHePmDGpPgnmjQcbUWLYiWmEyEUOmv9j2rQ/g==
+"@gltf-transform/extensions@^3.0.0-alpha.4":
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@gltf-transform/extensions/-/extensions-3.0.0-alpha.4.tgz#d6d5cdf08669f780f5c16be1b5a799dab6b1abf5"
+  integrity sha512-IzHXO/KvdBc045dJ5YqJaVF/yUClvyeuC5Yh0PRUS9W6/+OBpqw9i+yuPQzlJe7V/3v6ouT/HWvr1/QHxNalqg==
   dependencies:
-    "@gltf-transform/core" "^3.0.0-alpha.3"
+    "@gltf-transform/core" "^3.0.0-alpha.4"
     ktx-parse "^0.4.5"
 
-"@gltf-transform/functions@^3.0.0-alpha.3":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@gltf-transform/functions/-/functions-3.0.0-alpha.3.tgz#3fdedee99300ac438a21e515d3ce03401a367b2a"
-  integrity sha512-gpvGYB70Zl7tAcD1fgpQPIuWycthDB1BaRIHvMLTOfsXKYABBz5FqOQ/P3ADZxg1RGaK5Hi54hqciFVWWXBa/g==
+"@gltf-transform/functions@^3.0.0-alpha.4":
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@gltf-transform/functions/-/functions-3.0.0-alpha.4.tgz#dee5181bfc59356186ace07e7f18c804de0c2da6"
+  integrity sha512-K5iINos3B+g6cOrXTF5NyyhghP01aO+fRW5Rp1fDFTWtnnoi1/bBjJFRNm/oLxHgvCuiGdvj3cnmkqcBtz/TjQ==
   dependencies:
-    "@gltf-transform/core" "^3.0.0-alpha.3"
-    "@gltf-transform/extensions" "^3.0.0-alpha.3"
+    "@gltf-transform/core" "^3.0.0-alpha.4"
+    "@gltf-transform/extensions" "^3.0.0-alpha.4"
     gl-matrix "~3.4.3"
     ktx-parse "^0.4.5"
     ndarray "^1.0.19"


### PR DESCRIPTION
- Fixes #180 

The `@next` tag is a prerelease, and it looks like https://github.com/donmccurdy/glTF-Transform/issues/715 broke Draco compression here, renaming DracoMeshCompression to KHRDracoMeshCompression. Switching to the `draco()` helper would be backward-compatible for anyone still using the previous glTF Transform release.

The only remaining breaking change planned for v3 is a switch to ESM-only builds. It looks like gltfjsx should be good there, but just FYI!