### PR TITLE
Added support to render Threlte components from gltf files.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,12 +35,14 @@ const cli = meow(
         --ratio         Simplifier ratio (default: 0.75)
         --error         Simplifier error threshold (default: 0.001)
     --debug, -D         Debug output
+    --threlte           Transform to Threlte component
 `,
   {
     importMeta: import.meta,
     flags: {
       output: { type: 'string', alias: 'o' },
       types: { type: 'boolean', alias: 't' },
+      threlte: { type: 'boolean', alias: 'T' },
       keepnames: { type: 'boolean', alias: 'k' },
       keepgroups: { type: 'boolean', alias: 'K' },
       shadows: { type: 'boolean', alias: 's' },
@@ -76,7 +78,8 @@ Command: npx gltfjsx@${packageJson.version} ${process.argv.slice(2).join(' ')}`,
   const filePath = path.resolve(__dirname, file)
   let nameExt = file.match(/[-_\w]+[.][\w]+$/i)[0]
   let name = nameExt.split('.').slice(0, -1).join('.')
-  const output = name.charAt(0).toUpperCase() + name.slice(1) + (config.types ? '.tsx' : '.jsx')
+  const baseName = name.charAt(0).toUpperCase() + name.slice(1)
+  const output = baseName + (config.threlte ? '.svelte' : config.types ? '.tsx' : '.jsx')
   const showLog = (log) => {
     console.info('log:', log)
   }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "jsdom-global": "^3.0.2",
     "meow": "^11.0.0",
     "meshoptimizer": "^0.18.1",
-    "prettier": "^2.3.2",
+    "prettier": "^2.8.3",
+    "prettier-plugin-svelte": "^2.9.0",
     "sharp": "^0.31.3",
+    "svelte": "^3.55.1",
     "three": "0.122.0"
   },
   "devDependencies": {

--- a/src/gltfjsx.js
+++ b/src/gltfjsx.js
@@ -53,16 +53,30 @@ export default function (file, output, options) {
           arrayBuffer,
           '',
           (gltf) => {
-            stream.write(
-              prettier.format(parse(filePath, gltf, options), {
-                semi: false,
-                printWidth: options.printwidth || 1000,
-                singleQuote: true,
-                jsxBracketSameLine: true,
-                parser: options.types ? 'babel-ts' : 'babel',
-                //plugins: [parserBabel],
-              })
+            const raw = parse(filePath, gltf, options)
+            const prettiered = prettier.format(
+              raw,
+              options.threlte
+                ? {
+                    semi: false,
+                    bracketSameLine: true,
+                    svelteBracketNewLine: false,
+                    printWidth: options.printwidth || 1000,
+                    svelteBracketNewLine: true,
+                    singleQuote: true,
+                    parser: 'svelte',
+                    plugins: ['prettier-plugin-svelte'],
+                  }
+                : {
+                    semi: false,
+                    printWidth: options.printwidth || 1000,
+                    singleQuote: true,
+                    jsxBracketSameLine: true,
+                    parser: options.types ? 'babel-ts' : 'babel',
+                    //plugins: [parserBabel],
+                  }
             )
+            stream.write(prettiered)
             stream.end()
             resolve()
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,10 +1654,15 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-prettier@^2.3.2:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
-  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+prettier-plugin-svelte@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.9.0.tgz#16cc7fa73fa96eaef48b44089753ac9f1f1175e5"
+  integrity sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==
+
+prettier@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
+  integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
 
 property-graph@^0.2.6:
   version "0.2.6"
@@ -2076,6 +2081,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+svelte@^3.55.1:
+  version "3.55.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.55.1.tgz#6f93b153e5248039906ce5fe196efdb9e05dfce8"
+  integrity sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
First of all thanks for cracking the tough nuts on this great tool.

This PR brings support for rendering [Threlte](https://threlte.xyz) components instead of JSX with the flag `--threlte`.

Since Threlte [now also supports *rendering* instead of wrapping components](https://threlte.xyz/core-transition), a lot of the tools code can be used to render Threlte components instead of JSX.

It currently supports:
- Animations (using the [useGltfAnimations](https://threlte.xyz/extras/use-gltf-animations) hook)
- TypeScript

It does not support Instancing at the moment. Since Threlte render components are still quite new, we're in the process of transitioning that part to our new component syntax.

I separated the functions where needed to either print JSX or Threlte so there are as little as possible control flows. While at it, I updated prettier. To format Svelte components with prettier, Svelte must be installed alongside `prettier-plugin-svelte`.

## Example

Comparison between JSX output and Threlte output for a skinned mesh with animations and TypeScript types:

<details>
<summary>
JSX
</summary>

```jsx
/*
Auto-generated by: https://github.com/pmndrs/gltfjsx
Command: npx gltfjsx@6.1.3 ./stacy.glb -t
*/

import * as THREE from 'three'
import React, { useRef } from 'react'
import { useGLTF, useAnimations } from '@react-three/drei'
import { GLTF } from 'three-stdlib'

type GLTFResult = GLTF & {
  nodes: {
    stacy: THREE.SkinnedMesh
    mixamorigHips: THREE.Bone
  }
  materials: {}
}

type ActionName = 'pockets' | 'rope' | 'swingdance' | 'jump' | 'react' | 'shrug' | 'wave' | 'golf' | 'idle'
type GLTFActions = Record<ActionName, THREE.AnimationAction>

export function Model(props: JSX.IntrinsicElements['group']) {
  const group = useRef<THREE.Group>()
  const { nodes, materials, animations } = useGLTF('/stacy.glb') as GLTFResult
  const { actions } = useAnimations<GLTFActions>(animations, group)
  return (
    <group ref={group} {...props} dispose={null}>
      <group name="Scene">
        <group name="Stacy" rotation={[Math.PI / 2, 0, 0]} scale={0.01}>
          <primitive object={nodes.mixamorigHips} />
          <skinnedMesh name="stacy" geometry={nodes.stacy.geometry} material={nodes.stacy.material} skeleton={nodes.stacy.skeleton} rotation={[-Math.PI / 2, 0, 0]} scale={100} />
        </group>
      </group>
    </group>
  )
}

useGLTF.preload('/stacy.glb')
```

</details>


<details>
<summary>
Threlte
</summary>

```html
<!--
Auto-generated by: https://github.com/pmndrs/gltfjsx
Command: npx gltfjsx@6.1.3 ./stacy.glb -t --threlte
-->
<script lang="ts">
  import type * as THREE from 'three'
  import { Group } from 'three'
  import { T, Three, type Props, type Events, type Slots } from '@threlte/core'
  import { useGltf, useGltfAnimations } from '@threlte/extras'

  type $$Props = Props<THREE.Group>
  type $$Events = Events<THREE.Group>
  type $$Slots = Slots<THREE.Group>

  export const ref = new Group()

  type ActionName = 'pockets' | 'rope' | 'swingdance' | 'jump' | 'react' | 'shrug' | 'wave' | 'golf' | 'idle'
  type GLTFResult = {
    nodes: {
      stacy: THREE.SkinnedMesh
      mixamorigHips: THREE.Bone
    }
    materials: {}
  }

  const { gltf } = useGltf<GLTFResult>('/stacy.glb')
  export const { actions, mixer } = useGltfAnimations<ActionName>(gltf, ref)
</script>

{#if $gltf}
  <Three type={ref} {...$$restProps}>
    <T.Group name="Scene">
      <T.Group name="Stacy" rotation={[Math.PI / 2, 0, 0]} scale={0.01}>
        <Three type={$gltf.nodes.mixamorigHips} />
        <T.SkinnedMesh name="stacy" geometry={$gltf.nodes.stacy.geometry} material={$gltf.nodes.stacy.material} skeleton={$gltf.nodes.stacy.skeleton} rotation={[-Math.PI / 2, 0, 0]} scale={100} />
      </T.Group>
    </T.Group>

    <slot {ref} />
  </Three>
{/if}
```

</details>

When you're fine with merging it, I'll extend the docs with a little paragraph about Threlte support.