### PR TITLE
Fix `output` command-line flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -76,7 +76,7 @@ Command: npx gltfjsx@${packageJson.version} ${process.argv.slice(2).join(' ')}`,
   const filePath = path.resolve(__dirname, file)
   let nameExt = file.match(/[-_\w]+[.][\w]+$/i)[0]
   let name = nameExt.split('.').slice(0, -1).join('.')
-  const output = name.charAt(0).toUpperCase() + name.slice(1) + (config.types ? '.tsx' : '.jsx')
+  const output = config.output ?? name.charAt(0).toUpperCase() + name.slice(1) + (config.types ? '.tsx' : '.jsx')
   const showLog = (log) => {
     console.info('log:', log)
   }

--- a/cli.js
+++ b/cli.js
@@ -73,7 +73,6 @@ if (cli.input.length === 0) {
 Command: npx gltfjsx@${packageJson.version} ${process.argv.slice(2).join(' ')}`,
   }
   const file = cli.input[0]
-  const filePath = path.resolve(__dirname, file)
   let nameExt = file.match(/[-_\w]+[.][\w]+$/i)[0]
   let name = nameExt.split('.').slice(0, -1).join('.')
   const output = config.output ?? name.charAt(0).toUpperCase() + name.slice(1) + (config.types ? '.tsx' : '.jsx')


### PR DESCRIPTION
It seems like the `output` command-line flag/option is ignored since commit 94ad0321364561bf07ca47c5ab808871eabc08bb broke it by accident during migration of some logic from `src/components/App.js` to `cli.js`. With this change the output flag takes precedence if provided, as before. I also removed the unused `filePath` variable.