### PR TITLE
Fix/101: Type 'GLTFActions'  constraint to 'AnimationClip'

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -63,7 +63,7 @@ const cli = meow(
       keepmeshes: { type: 'boolean', shortFlag: 'j', default: false },
       keepmaterials: { type: 'boolean', shortFlag: 'M', default: false },      
       format: { type: 'string', shortFlag: 'f', default: 'webp' },
-      exportdefault: { type: 'boolean', alias: 'E' },
+      exportdefault: { type: 'boolean', shortFlag: 'E' },
       weld: { type: 'number', default: 0.0001 },
       ratio: { type: 'number', default: 0.75 },
       error: { type: 'number', default: 0.001 },

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -120,7 +120,7 @@ function parse(gltf, { fileName = 'model', ...options } = {}) {
       ${materials.map(({ name, type }) => (isVarName(name) ? name : `['${name}']`) + ': THREE.' + type).join(',')}
     }
     animations: GLTFAction[]
-  }\n${animationTypes}`
+  }\n${animationTypes}\n${contextType}`
   }
 
   function getType(obj) {

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -94,7 +94,9 @@ function parse(fileName, gltf, options = {}) {
     if (animations.length) {
       animationTypes = `\n
   type ActionName = ${animations.map((clip, i) => `"${clip.name}"`).join(' | ')};
-  type GLTFActions = Record<ActionName, THREE.AnimationAction>;\n`
+  interface GLTFAction extends THREE.AnimationClip {\n
+    name: ActionName;\n
+  }`
     }
 
     return `\ntype GLTFResult = GLTF & {
@@ -105,6 +107,7 @@ function parse(fileName, gltf, options = {}) {
     materials: {
       ${materials.map(({ name, type }) => (isVarName(name) ? name : `['${name}']`) + ': THREE.' + type).join(',')}
     }
+    animations: GLTFAction[]
   }\n${animationTypes}`
   }
 
@@ -351,9 +354,7 @@ function parse(fileName, gltf, options = {}) {
   }
 
   function printAnimations(animations) {
-    return animations.length
-      ? `\nconst { actions } = useAnimations${options.types ? '<GLTFActions>' : ''}(animations, group)`
-      : ''
+    return animations.length ? `\nconst { actions } = useAnimations(animations, group)` : ''
   }
 
   function parseExtras(extras) {


### PR DESCRIPTION
### What kind of problem this solves

- [x] - Bug Fixes
- [ ] - New Feature
- [ ] - Breaking Change
- [ ] - Documentation Updates

### Context

This PR look to solve the problem addressed on the Issue 101:
[issue-101](https://github.com/pmndrs/gltfjsx/issues/101)

The solution proposed by @Glavin001 seams to be great and solve the issue with good clean types reducing complexity on useAnimation hook.

### How to test

- Run the the gltfjsx.js file
- Import `.glb | .gltf` file
- Look for a typed JSX the follows this standard:
```js
 // ...
 interface GLTFAction extends THREE.AnimationClip {
   name: ActionName;
}
// ...
type GLTFResult = GLTF & {
  nodes: {
// ...
  }
  materials: {
// ...
  }
  animations: GLTFAction[];
}
// ...
const { actions } = useAnimations(animations, group);
```

### Issue

[issue-101](https://github.com/pmndrs/gltfjsx/issues/101)