### PR TITLE
Fix output file bugs

### DIFF
--- a/src/gltfjsx.js
+++ b/src/gltfjsx.js
@@ -28,7 +28,7 @@ export default function (file, output, options) {
   }
 
   return new Promise((resolve, reject) => {
-    const stream = fs.createWriteStream(output)
+    const stream = fs.createWriteStream(path.resolve(output))
     stream.once('open', async (fd) => {
       if (!fs.existsSync(file)) {
         reject(file + ' does not exist.')
@@ -36,7 +36,8 @@ export default function (file, output, options) {
         // Process GLTF
         if (options.transform || options.instance || options.instanceall) {
           const { name } = path.parse(file)
-          const transformOut = path.join(name + '-transformed.glb')
+          const outputDir = path.parse(path.resolve(output ?? file)).dir;
+          const transformOut = path.join(outputDir, name + '-transformed.glb')
           await transform(file, transformOut, options)
           file = transformOut
         }

--- a/src/gltfjsx.js
+++ b/src/gltfjsx.js
@@ -34,6 +34,10 @@ export default function (file, output, options) {
         reject(file + ' does not exist.')
       } else {
         // Process GLTF
+        if (output && path.parse(output).ext === '.tsx') {
+          options.types = true
+        }
+        
         if (options.transform || options.instance || options.instanceall) {
           const { name } = path.parse(file)
           const outputDir = path.parse(path.resolve(output ?? file)).dir;


### PR DESCRIPTION
Output files/directories were being ignored and defaulting to the root directory. This PR fixes that. Also, if the output file specified has a `.tsx` extension, output Typescript by default.