### PR TITLE
[🐞 Bug Fix] 6.2.8 breaks parsing of models with interleaved buffers

### DIFF
--- a/src/bin/GLTFLoader.js
+++ b/src/bin/GLTFLoader.js
@@ -1672,7 +1672,11 @@ GLTFParser.prototype.loadAccessor = function (accessorIndex) {
       }
     }
 
-    bufferAttribute.count = accessorDef.count
+    if (bufferAttribute.isInterleavedBufferAttribute) {
+      bufferAttribute.data.count = accessorDef.count
+    } else {
+      bufferAttribute.count = accessorDef.count
+    }
     return bufferAttribute
   })
 }


### PR DESCRIPTION
## Issue

After updating to 6.2.8, parsing 3D models with interleaved buffer always gives the following error.

```sh
TypeError: Cannot set property count of #<InterleavedBufferAttribute> which has only a getter
    at file:///<redacted>/node_modules/.pnpm/gltfjsx@6.2.8/node_modules/gltfjsx/src/bin/GLTFLoader.js:1675:27
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async Promise.all (index 1)
    at async Promise.all (index 0)
    at async Promise.all (index 1)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
```

## Investigation

In [/src/bin/GLTFLoader.js#L1675](https://github.com/pmndrs/gltfjsx/blob/v6.2.8/src/bin/GLTFLoader.js#L1675), the `count` property of `bufferAttribute` is assigned an updated value.

```js
// ...
bufferAttribute.count = accessorDef.count
// ...
```

Prior to the assignment, `bufferAttribute` was instantiated as either [`BufferAttribute`](https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js) or [`InterleavedBufferAttribute`](https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js). This is fine for [`BufferAttribute`](https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js) as its `count` property is mutable.

However, in [`InterleavedBufferAttribute`](https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js), `count` is just a getter that returns the count of the underlying [`InterleavedBuffer`](https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBuffer.js). Attempting to assign a new value to `count` will throw an error.

[https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js#L23](https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js#L23)
```js
get count() {
  return this.data.count;
}
```

This issue doesn't apply to versions prior to 6.2.8 because the line was newly added to this version.

## Solution

I made a very small fix to update `count` differently if the `bufferAttribute` is a [`InterleavedBufferAttribute`](https://github.com/mrdoob/three.js/blob/master/src/core/InterleavedBufferAttribute.js).

```js
if (bufferAttribute.isInterleavedBufferAttribute) {
  bufferAttribute.data.count = accessorDef.count
} else {
  bufferAttribute.count = accessorDef.count
}
```