### PR TITLE
Update README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ export function Model(props) {
   )
 }
 
-useGLTF.preload('/model.gltf')
+useGLTF.preload('/model-transformed.gltf')
 ```
 
 Add your model to your `/public` folder as you would normally do. With the `--transform` flag it has created a compressed copy of it (in the above case `model-transformed.glb`). Without the flag just copy the original model.


### PR DESCRIPTION
Hopefully it is not me who got it wrong :D but it seems that in the initial example we should've used `model-transformed.gltf` in the `preload()` call instead of `model.gltf`.