### PR TITLE
Readme: Explicit optionalConfig json object options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,29 @@ gltfLoader.load(url, (gltf) => {
 })
 ```
 
+<details>
+  <summary>Where `optionalConfig` can take values config options among these </summary>
+
+```js
+optionalConfig = {
+  debug: true, 
+  // User content
+  keepnames: true, 
+  keepgroups: true, 
+  meta: true, 
+  header: 'Header',
+  // User content
+  types: true, 
+  shadows: true,
+  exportdefault: true, 
+  precision: 3,
+  instance: false,
+  instanceall: false
+  // draco 
+}
+```
+</details>
+
 ## Using the parser stand-alone for scenes (object3d's)
 
 ```jsx


### PR DESCRIPTION
Simply added this section to the readme within a details note:

```js
optionalConfig = {
  debug: true, 
  // User content
  keepnames: true, 
  keepgroups: true, 
  meta: true, 
  header: 'Header',
  // User content
  types: true, 
  shadows: true,
  exportdefault: true, 
  precision: 3,
  instance: false,
  instanceall: false
  // draco 
}
```