### PR TITLE
Add parseRaw to output parsed component tree jsx string without passing though prettier

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -3,7 +3,7 @@ import * as prettier from 'prettier'
 import babelParser from 'prettier/parser-babel.js'
 import isVarName from './isVarName.js'
 
-function parse(gltf, { fileName = 'model', ...options } = {}) {
+function parseRaw(gltf, { fileName = 'model', ...options } = {}) {
   if (gltf.isObject3D) {
     // Wrap scene in a GLTF Structure
     gltf = { scene: gltf, animations: [], parser: { json: {} } }
@@ -498,6 +498,11 @@ useGLTF.preload('${url}')`
 
   console.log(header)
   const output = header + '\n' + result
+  return output;
+}
+
+export default function parse(gltf, { fileName = 'model', ...options } = {}) {
+  const output = parseRaw(gltf, { fileName, ...options })
   return prettier.format(output, {
     semi: false,
     printWidth: options.printwidth || 1000,
@@ -508,4 +513,4 @@ useGLTF.preload('${url}')`
   })
 }
 
-export default parse
+export {parseRaw}


### PR DESCRIPTION
I stumbled upon the below error setting up a React project with Vite and trying to use the `gltfjsx` parser standalone.

```bash
npm create vite@latest my-app --template react
```

The error raised is the following: `Cannot read properties of undefined (reading 'languages')` and it occurs during the return of the `parse` function at `return prettier.format(output, {...` 

![image](https://github.com/pmndrs/gltfjsx/assets/16822841/7cea0466-f2cb-4b8c-9dd1-55938837ba51)

This PR aims as a workaround to add another exported parser function, `parseRaw` which outputs the raw string. The original `parse` function gets output from parseRaw and return the prettier result on top of it as before. 

