### PR TITLE
Add support for KTX2 loader

### DIFF
--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -18,6 +18,7 @@ function parse(gltf, { fileName = 'model', ...options } = {}) {
   gltf.scene.traverse((child) => objects.push(child))
   const json = gltf.parser.json;
   const needsDraco = json.extensionsRequired && json.extensionsRequired.includes('KHR_draco_mesh_compression');
+  const needsMeshopt = json.extensionsUsed && json.extensionsUsed.includes('KHR_meshopt_compression');
   const needsKTX2Loader = json.extensionsRequired && json.extensionsRequired.includes('KHR_texture_basisu');
 
   // Browse for duplicates
@@ -497,7 +498,7 @@ ${parseExtras(gltf.parser.json.asset && gltf.parser.json.asset.extras)}*/`
               ? `const { nodes, materials${hasAnimations ? ', animations' : ''} } = useGLTF('${url}'${
                   needsDraco ? ", true" : options.draco ? `, ${JSON.stringify(options.draco)}` : ', false'
                 }
-                  , false, ${needsKTX2Loader ? `(loader) => {
+                  , ${needsMeshopt ? 'true' : 'false'}, ${needsKTX2Loader ? `(loader) => {
                       const { gl } = useThree();
                       const THREE_PATH = \`https://unpkg.com/three@0.$\{REVISION\}.x\`;
                       const ktx2Loader = new KTX2Loader().setTranscoderPath(\`$\{THREE_PATH\}/examples/jsm/libs/basis/\`);


### PR DESCRIPTION
This PR adds support for KTX2 loader codegen since currently files with basisu compressed textures can not be loaded with gltfjsx codegen. 

It also enables the draco option or meshopt option automatically if the mesh uses draco/meshopt compression.

Output Example: 
https://codesandbox.io/p/sandbox/example-gltfjsx-ktx-draco-zq868k?workspaceId=6fd5c640-33c5-4061-bc17-d4030f1a6650


Steps to reproduce:
1) Load [compressed DamagedHelmet](https://cloud.needle.tools/api/v1/public/9162350/10b73680/DamagedHelmet.glb)
2) Drop into https://gltf.pmnd.rs/
3) Observe error


This PR might be actually better suited as an option for [drei useGLTF](https://github.com/pmndrs/drei/blob/595396507dbedbd0ff678945cd7c425db736f759/src/core/Gltf.tsx#L12) to avoid creating KTX2 loaders for every model (as we do with this PR). It would also simplify codegen again.
Let me know if you'd prefer this as a third bool argument (similar to draco and meshopt) and if so in what fashion (before the loader callback parameter or after) or if you prefer a different solution.




